### PR TITLE
feat: add .moltfounders/ agent rules directory

### DIFF
--- a/.moltfounders/README.md
+++ b/.moltfounders/README.md
@@ -1,0 +1,22 @@
+# .moltfounders/
+
+This directory defines how AI agents maintain this repository.
+
+Agents participating in the [MoltFounders](https://moltfounders.com) workspace for this repo read these files on every run and follow them exactly. Rules are versioned here like code — propose changes via PR.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `labels.md` | Canonical GitHub label definitions |
+| `issue-triage.md` | How to triage and respond to issues |
+| `pr-review.md` | How to review pull requests |
+| `research.md` | How to discover and suggest new autoresearch resources |
+| `staleness.md` | How to handle stale issues and PRs |
+
+## Principles
+
+- **Agents prepare, humans decide.** Agents review, comment, and label. Only the maintainer merges.
+- **Idempotent by default.** Once an agent has handled an item, it won't touch it again unless the label is removed.
+- **Strict lineage bar.** This is a curated list — not a dump of "AI research" projects. Every entry must have a clear autoresearch connection.
+- **Community-editable.** Want to change how the repo is maintained? Open a PR against these files.

--- a/.moltfounders/issue-triage.md
+++ b/.moltfounders/issue-triage.md
@@ -1,0 +1,59 @@
+# Issue Triage Rules
+
+## When to Run
+
+On every agent loop cycle, scan all open issues.
+
+## Skip Conditions
+
+- Issue already has `agent:reviewed` label → skip entirely
+- Issue was opened by an agent → skip
+- GitHub-generated issue → skip
+
+## Triage Steps
+
+### 1. Classify the issue type
+
+- **Addition request** — someone wants a new project added
+- **Removal request** — entry is stale, wrong, or weak
+- **Correction** — fixing description, link, or section placement
+- **Question / discussion** — not a concrete change request
+- **Spam / off-topic** — unrelated
+
+### 2. Evaluate addition requests
+
+The **primary bar** (from CONTRIBUTING.md): the project must be:
+- directly inspired by `karpathy/autoresearch`, OR
+- explicitly cites autoresearch as a foundation, OR
+- clearly uses the same autonomous improvement loop pattern in a meaningful adjacent domain
+
+**Secondary checks:**
+- Is the repo real and accessible?
+- Is it not already in the list? (Search README)
+- Does it fit an existing section?
+- Is it actively maintained or a useful reference?
+
+**Not sufficient alone:**
+- "It's an AI research agent" — must have autoresearch lineage
+- "It does autonomous improvement" — must connect to the autoresearch loop pattern specifically
+- Being adjacent is ok for the Related Resources section, but connection must be obvious
+
+### 3. Comment with clear verdict
+
+- What you checked
+- Whether it meets the autoresearch connection bar
+- If not, explain specifically what's missing
+- If yes, suggest the right section and invite a PR
+
+### 4. Apply labels
+
+- Always apply `agent:reviewed`
+- Apply `agent:commented` if you left a comment
+- Apply `no-autoresearch-connection`, `duplicate`, or `needs-info` as appropriate
+- Apply `needs-human` for borderline cases
+
+## Edge Cases
+
+- **Clearly autoresearch-derived but poorly described issue:** Ask for a PR instead of the issue
+- **Borderline connection:** Label `needs-info`, ask submitter to explain the autoresearch link specifically
+- **Issue >90 days, no activity:** Follow staleness rules in `staleness.md`

--- a/.moltfounders/labels.md
+++ b/.moltfounders/labels.md
@@ -1,0 +1,29 @@
+# Labels
+
+Canonical GitHub labels used by agents in this repository.
+
+## Agent Labels
+
+| Label | Color | Description |
+|-------|-------|-------------|
+| `agent:reviewed` | `#0075ca` | Reviewed by an agent — will not be re-reviewed automatically |
+| `agent:commented` | `#cfd3d7` | Agent left a comment on this item |
+| `agent:approved` | `#0e8a16` | Agent approved this PR — needs maintainer merge |
+| `agent:changes-requested` | `#e4e669` | Agent requested changes on this PR |
+| `agent:suggested` | `#d4edda` | Agent suggested this entry via research loop |
+
+## Status Labels
+
+| Label | Color | Description |
+|-------|-------|-------------|
+| `needs-human` | `#e11d48` | Needs maintainer attention — agent could not resolve |
+| `stale` | `#ededed` | No activity for an extended period |
+| `duplicate` | `#cfd3d7` | Already exists in the list |
+| `no-autoresearch-connection` | `#b60205` | Project lacks clear autoresearch lineage or loop pattern |
+| `needs-info` | `#fbca04` | Waiting on submitter to clarify autoresearch connection |
+| `wrong-section` | `#e4e669` | Placed in incorrect section |
+
+## Setup
+
+Agents should ensure all labels above exist in the repo before executing loops.
+If a label is missing, create it with the specified color and description via gh CLI.

--- a/.moltfounders/pr-review.md
+++ b/.moltfounders/pr-review.md
@@ -1,0 +1,80 @@
+# PR Review Rules
+
+## When to Run
+
+On every agent loop cycle, scan all open PRs.
+
+## Skip Conditions
+
+- PR already has `agent:reviewed` → skip entirely
+- PR is a draft → skip
+- PR was opened by an agent → skip
+- Bot PR → label `needs-human`, skip
+
+## Review Steps
+
+### 1. Understand what the PR adds
+
+Read the PR title, description, and diff.
+
+### 2. Autoresearch connection check (primary bar)
+
+This is the most important check. The project must satisfy at least one:
+- **Explicit lineage:** Directly forked from or explicitly builds on `karpathy/autoresearch`
+- **Explicit citation:** README or docs cite autoresearch as inspiration/foundation
+- **Same loop pattern:** Uses the autonomous keep-or-revert improvement loop in a meaningful way (not just "it does AI")
+
+If the connection is absent or tenuous → request changes with `no-autoresearch-connection`. Ask the submitter to clarify.
+
+### 3. Format checks (from CONTRIBUTING.md)
+
+Preferred entry format:
+```
+- [owner/repo](url) - Short, neutral description.
+```
+Stars badge is optional but accepted. Check:
+- Is the description short, factual, non-promotional?
+- Is the link valid?
+- Is it in the correct section?
+- No marketing copy or keyword stuffing?
+
+### 4. Content checks
+
+- **Duplicate:** Search README for the repo URL and name
+- **Section fit:** Does it belong where it was placed? Sections:
+  - General-purpose descendants
+  - Research-agent systems
+  - Platform ports and hardware forks
+  - Domain-specific adaptations
+  - Evaluation & benchmarks
+  - Notable use cases and writeups
+  - Related resources
+- **Quality:** Is it a real, functional project? Not a stub or empty repo?
+
+### 5. Leave your review
+
+Be specific:
+- State clearly whether it passes the autoresearch connection bar
+- Note any format issues
+- If approving: confirm the connection explicitly
+- If requesting changes: give actionable, friendly guidance
+
+### 6. Apply labels and set status
+
+- Always apply `agent:reviewed`
+- Apply `agent:approved` if it passes all checks
+- Apply `agent:changes-requested` if issues found
+- Apply `no-autoresearch-connection`, `wrong-section`, `duplicate` as needed
+- Apply `needs-human` for genuinely borderline cases
+
+## Important: Agent approval ≠ merge
+
+Only the maintainer merges.
+
+## Edge Cases
+
+- **PR adds to Related Resources section:** Lower bar — "adjacent but related" is fine here, still needs obvious connection to the space
+- **PR fixes a broken link or formatting only:** Fast-track approve
+- **Stars badge missing from entry:** Not a blocker — format is flexible per CONTRIBUTING.md
+- **PR has been open >30 days with no author response:** Follow staleness rules
+- **Submitter disputes the autoresearch connection:** Label `needs-human` — this is a judgment call for the maintainer

--- a/.moltfounders/research.md
+++ b/.moltfounders/research.md
@@ -1,0 +1,49 @@
+# Research Loop Rules
+
+## Purpose
+
+Periodically discover new autoresearch-related projects worth adding and open issues suggesting them.
+
+## Frequency
+
+Run once per week. Do not run if you already opened a research issue in the last 7 days (check `agent:suggested` label).
+
+## Sources to Check
+
+1. **GitHub search** — `karpathy autoresearch fork`, `autoresearch loop`, `keep-or-revert` in repo descriptions/READMEs
+2. **GitHub network** — forks of `karpathy/autoresearch` sorted by recently updated
+3. **Papers with Code / arXiv** — new papers citing autoresearch or describing autonomous improvement loops
+4. **Twitter/X** — search `autoresearch karpathy`, `autoresearch loop` for recent demos
+5. **Hacker News** — search for autoresearch mentions in Show HN or recent posts
+
+## Qualification Criteria
+
+A project qualifies if:
+- Clear autoresearch connection (lineage, citation, or same loop pattern)
+- Real functional repo (not a stub)
+- Not already in the list (search README before suggesting)
+- Fits an existing section
+
+## How to Suggest
+
+Open a GitHub issue with:
+- **Title:** `[Research] Add: <owner/repo>`
+- **Body:**
+  - Repo URL
+  - One-sentence description
+  - Autoresearch connection (explicit — what makes this autoresearch-lineage?)
+  - Suggested section
+  - Source where you found it
+
+Apply label `agent:suggested`.
+
+## Limits
+
+- At most **3 research issues per cycle**
+- Check existing `agent:suggested` issues to avoid duplicates
+
+## Edge Cases
+
+- **Very new fork (<1 week):** Still suggest if clearly autoresearch-derived
+- **Writeup/blog post (no repo):** Suggest for Notable Use Cases section if it documents a real autoresearch-style run
+- **Paper with open implementation:** Suggest if the paper explicitly relates to the autoresearch loop pattern

--- a/.moltfounders/staleness.md
+++ b/.moltfounders/staleness.md
@@ -1,0 +1,39 @@
+# Staleness Rules
+
+## Purpose
+
+Keep the issue tracker and PR queue clean.
+
+## Issues
+
+### Waiting on submitter (`needs-info` label)
+- No response after **14 days**: post a friendly reminder
+- No response after **30 days**: apply `stale`, note will close in 7 days
+- No response after **37 days**: close politely; can be reopened
+
+### General open issues
+- Open >90 days with no `agent:reviewed`: triage now
+- Open >90 days with `agent:reviewed`, no further activity: apply `stale`, ask if still relevant
+- Stale another 14 days: label `needs-human`
+
+## Pull Requests
+
+### Awaiting author action (`agent:changes-requested`)
+- No response after **14 days**: friendly reminder
+- No response after **30 days**: apply `stale`, note will close in 7 days
+- No response after **37 days**: close with explanation; welcome to reopen
+
+### Merge conflicts
+- Comment immediately asking for rebase
+- Not resolved after **14 days**: apply `stale`
+- Not resolved after **30 days**: close
+
+### Approved but not merged (`agent:approved`)
+- Do not mark stale — maintainer's queue
+- Approved >30 days with no activity: label `needs-human`
+
+## Principles
+
+- Always be friendly — assume good intent
+- Never close without a clear comment explaining how to reopen
+- When in doubt: `needs-human` over closing


### PR DESCRIPTION
## What this adds

A `.moltfounders/` directory defining how AI agents maintain this repo.

### Files
- `README.md` — explains the directory and principles
- `labels.md` — canonical label definitions (incl. `no-autoresearch-connection`)
- `issue-triage.md` — triage rules tailored to autoresearch lineage bar
- `pr-review.md` — review criteria: lineage check, citation check, loop pattern check
- `research.md` — weekly discovery of new autoresearch forks, papers, writeups
- `staleness.md` — handling quiet issues and PRs

### Key design choice
Rules are explicitly tuned to this repo's strict quality bar: every entry must have direct autoresearch lineage, explicit citation, or clearly use the same autonomous keep-or-revert improvement loop. Generic 'AI research agent' projects don't qualify.