### PR TITLE
Add agent-driven nanochat baseline search on ML Patron

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
 - **Autoresearch 101 Builder's Playbook** - Substack deep-dive on applying autoresearch patterns to prompts, agents, and workflows with concrete examples. ([article](https://sidsaladi.substack.com/p/autoresearch-101-builders-playbook))
 - **Kingy AI Technical Breakdown** - Detailed technical walkthrough of the autoresearch loop architecture, mutation operators, and fitness function design. ([article](https://kingy.ai/ai/autoresearch-karpathys-minimal-agent-loop-for-autonomous-llm-experimentation/))
 - **Fortune Feature** - Business and industry context on why autoresearch matters for the future of autonomous AI agents. ([article](https://fortune.com/2026/03/17/andrej-karpathy-loop-autonomous-ai-agents-future/))
+- **Agent-driven nanochat baseline search on ML Patron** - Claude Code agent autonomously plans, funds, and iterates nanochat training runs on a cloud execution platform via API and skill.md. ([writeup](https://mlpatron.com/discussions/56cd48ab-0cc9-45ee-8cb3-5154f5b5112d) · [platform](https://mlpatron.com))
 
 ## 📚 Related resources
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@
 - **Autoresearch 101 Builder's Playbook** - Substack deep-dive on applying autoresearch patterns to prompts, agents, and workflows with concrete examples. ([article](https://sidsaladi.substack.com/p/autoresearch-101-builders-playbook))
 - **Kingy AI Technical Breakdown** - Detailed technical walkthrough of the autoresearch loop architecture, mutation operators, and fitness function design. ([article](https://kingy.ai/ai/autoresearch-karpathys-minimal-agent-loop-for-autonomous-llm-experimentation/))
 - **Fortune Feature** - Business and industry context on why autoresearch matters for the future of autonomous AI agents. ([article](https://fortune.com/2026/03/17/andrej-karpathy-loop-autonomous-ai-agents-future/))
-- **Agent-driven nanochat baseline search on ML Patron** - Claude Code agent autonomously plans, funds, and iterates nanochat training runs on a cloud execution platform via API and skill.md. ([writeup](https://mlpatron.com/discussions/56cd48ab-0cc9-45ee-8cb3-5154f5b5112d) · [platform](https://mlpatron.com))
+- **Agent-driven nanochat baseline search on ML Patron** - AI agent autonomously plans, funds, and iterates nanochat training runs on a public cloud execution platform via API and skill.md, with experiment notes published openly to foster collaboration. ([writeup](https://mlpatron.com/discussions/56cd48ab-0cc9-45ee-8cb3-5154f5b5112d) · [platform](https://mlpatron.com))
 
 ## 📚 Related resources
 


### PR DESCRIPTION
## Summary
- Adds a writeup entry under **Notable use cases and writeups**
- A Claude Code agent autonomously planned, funded, and iterated nanochat training runs on ML Patron (a cloud execution platform) via API and skill.md, with zero human button-clicks

## Links
- [Writeup](https://mlpatron.com/discussions/56cd48ab-0cc9-45ee-8cb3-5154f5b5112d)
- [Platform](https://mlpatron.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)