### PR TITLE
Add jeongph/autospec — spec-driven code generation loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@
 - [chrisworsey55/atlas-gic](https://github.com/chrisworsey55/atlas-gic) ![GitHub stars](https://img.shields.io/github/stars/chrisworsey55/atlas-gic?style=social) - Applies the autoresearch keep-or-revert loop to trading agents, optimizing prompts and portfolio orchestration against rolling Sharpe ratio instead of model loss.
 - [RightNow-AI/autokernel](https://github.com/RightNow-AI/autokernel) ![GitHub stars](https://img.shields.io/github/stars/RightNow-AI/autokernel?style=social) - Applies the autoresearch loop to GPU kernel optimization: profile bottlenecks, edit one kernel, benchmark, keep or revert, repeat.
 - [Rkcr7/autoresearch-sudoku](https://github.com/Rkcr7/autoresearch-sudoku) ![GitHub stars](https://img.shields.io/github/stars/Rkcr7/autoresearch-sudoku?style=social) - Enhanced autoresearch workflow where an AI agent iteratively rewrites and benchmarks a Rust sudoku solver, ultimately beating leading human-built solvers on hard benchmark sets.
+- [jeongph/autospec](https://github.com/jeongph/autospec) ![GitHub stars](https://img.shields.io/github/stars/jeongph/autospec?style=social) - Reads natural-language business rules and autonomously builds a Spring Boot service with tests via the keep-or-revert loop. Evaluates with Gradle build + JUnit XML. 119-line skeleton to 950 lines in 5 cycles.
 
 ## 📊 Evaluation & benchmarks
 


### PR DESCRIPTION
Adds [jeongph/autospec](https://github.com/jeongph/autospec) to the **Domain-specific adaptations** section.

**What it does:** Autonomous keep-or-revert loop that reads natural-language business specs (Korean) and iteratively builds a Spring Boot service with tests. Uses Claude Code CLI (`claude -p`), Gradle build + JUnit XML as the evaluation function, and `git reset --hard` as rollback.

**Why it fits:** Direct application of the autoresearch keep-or-revert pattern to specification-driven code generation from natural-language business rules — a domain not yet represented in this list.

**Demo results:** 119-line skeleton → 950 lines of working Java, 34 passing tests, 5 accepted cycles, 0 rejects, ~26 min, $0 cost.