### PR TITLE
Add Writing-Driven Autoresearch to Research-agent systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@
 - [PouriaRouzrokh/LatteReview](https://github.com/PouriaRouzrokh/LatteReview) - Low-code Python package for **automated systematic literature reviews** via AI-powered agents. ![GitHub stars](https://img.shields.io/github/stars/PouriaRouzrokh/LatteReview?style=social)
 - [LitLLM/LitLLM](https://github.com/LitLLM/LitLLM) - AI-powered literature review assistant using RAG for accurate, well-structured related-work sections in academic writing. ![GitHub stars](https://img.shields.io/github/stars/LitLLM/LitLLM?style=social)
 - [Agent Laboratory](https://agentlaboratory.github.io/) - Three-phase research pipeline: Literature Review → Experimentation → Report Writing, with specialized agents for each phase.
+- [happyhappy-jun/writing-driven-autoresearch](https://github.com/happyhappy-jun/writing-driven-autoresearch) - Autoresearch-style harness that keeps a submittable paper from the first minute and drives every experiment from the claims in that draft, looping modify → measure → verify → revise. 1st place at the [Ralphthon@ICML 2026](https://luma.com/hjuo7auc) autonomous-research hackathon. ![GitHub stars](https://img.shields.io/github/stars/happyhappy-jun/writing-driven-autoresearch?style=social)
 
 ## 💻 Platform ports and hardware forks
 


### PR DESCRIPTION
Adds happyhappy-jun/writing-driven-autoresearch to the Research-agent systems section.

An autoresearch-style harness that keeps a submittable paper from the first minute and drives every experiment from the claims in that draft, looping modify → measure → verify → revise. Writeup: https://byungjunyoon.ai/writing-driven-autoresearch/